### PR TITLE
Support any Monad

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -40,6 +40,7 @@ lazy val core = Project("fixql-core", file("fixql-core"))
 
     "com.h2database" % "h2" % "1.4.187" % Test,
   ))
+  .settings(addCompilerPlugin("com.olegpy" %% "better-monadic-for" % "0.3.0"))
 
 lazy val derivation = Project("fixql-derivation", file("fixql-derivation"))
   .settings(name := "fixql-derivation")

--- a/build.sbt
+++ b/build.sbt
@@ -35,10 +35,7 @@ lazy val core = Project("fixql-core", file("fixql-core"))
     "io.circe" %% "circe-parser" % "0.9.3",
     "io.circe" %% "circe-optics" % "0.9.3",
 
-    "com.typesafe.slick" %% "slick" % "3.2.3",
     "com.typesafe.play" %% "play-json" % "2.7.1",
-
-    "com.h2database" % "h2" % "1.4.187" % Test,
   ))
   .settings(addCompilerPlugin("com.olegpy" %% "better-monadic-for" % "0.3.0"))
 

--- a/fixql-core/src/main/scala/com/iterable/graphql/SchemaAndMappingsMutableBuilderDsl.scala
+++ b/fixql-core/src/main/scala/com/iterable/graphql/SchemaAndMappingsMutableBuilderDsl.scala
@@ -67,25 +67,25 @@ case class Builders[F[_]](
   * A mutable builder DSL to define schema and mappings simultaneously.
   * See [[BuilderSpec]] for example usage.
   */
-trait SchemaAndMappingsMutableBuilderDsl[F[_]] extends SchemaDsl {
+trait SchemaAndMappingsMutableBuilderDsl extends SchemaDsl {
 
-  protected final def schemaAndMappings(mutate: Builders[F] => Unit) = {
+  protected final def schemaAndMappings[F[_]](mutate: Builders[F] => Unit) = {
     val builders = Builders[F](queryTypeBuilder = objectType("QueryType"))
     mutate(builders)
     builders.schemaBuilder.query(builders.queryTypeBuilder.build)
     (builders.schemaBuilder.build, builders.mappingsBuilder.build)
   }
 
-  implicit def mappingsFromBuilders(implicit builder: Builders[F]): MutableMappingsBuilder[F] = builder.mappingsBuilder
+  implicit def mappingsFromBuilders[F[_]](implicit builder: Builders[F]): MutableMappingsBuilder[F] = builder.mappingsBuilder
 
   /** The Query type uses an ordinary object builder. But since we can't have multiple implicit object builders in
     * lexical scope, uses of the query type builder must be delimited.
     */
-  protected final def withQueryType(mutate: GraphQLObjectType.Builder => Unit)(implicit builder: Builders[F]) = {
+  protected final def withQueryType[F[_]](mutate: GraphQLObjectType.Builder => Unit)(implicit builder: Builders[F]) = {
     mutate(builder.queryTypeBuilder)
   }
 
-  protected final def addMappings(mappings: QueryMappings[F])(implicit mappingsBuilder: MutableMappingsBuilder[F]): Unit = {
+  protected final def addMappings[F[_]](mappings: QueryMappings[F])(implicit mappingsBuilder: MutableMappingsBuilder[F]): Unit = {
     mappingsBuilder.add(mappings)
   }
 
@@ -104,7 +104,7 @@ trait SchemaAndMappingsMutableBuilderDsl[F[_]] extends SchemaDsl {
   }
 
   implicit class FieldExtensions(field: GraphQLFieldDefinition) {
-    def ~>(reducer: QueryReducer[F, JsValue])
+    def ~>[F[_]](reducer: QueryReducer[F, JsValue])
           (implicit builders: Builders[F], obj: GraphQLObjectType.Builder, mappings: MutableMappingsBuilder[F]) = {
       obj.field(field)
       val ObjectName = obj.build.getName

--- a/fixql-core/src/main/scala/com/iterable/graphql/compiler/Compiler.scala
+++ b/fixql-core/src/main/scala/com/iterable/graphql/compiler/Compiler.scala
@@ -1,6 +1,6 @@
 package com.iterable.graphql.compiler
 
-import cats.Monad
+import cats.Functor
 import com.iterable.graphql.Field
 import com.iterable.graphql.Query
 import play.api.libs.json.JsObject
@@ -16,7 +16,7 @@ object Compiler {
     * generates the root resolver, then runs it.
     * @return an object of the query type
     */
-  def compile[F[_] : Monad](schema: Schema, query: Query[Field.Fixed], mappings: QueryMappings[F]): F[JsObject] = {
+  def compile[F[_] : Functor](schema: Schema, query: Query[Field.Fixed], mappings: QueryMappings[F]): F[JsObject] = {
     val annotated: Query[Field.Annotated[FieldTypeInfo]] = annotateWithTypeInfo(schema, query)
 
     val mappingsFn = toMappingFunction(mappings)

--- a/fixql-core/src/main/scala/com/iterable/graphql/compiler/Compiler.scala
+++ b/fixql-core/src/main/scala/com/iterable/graphql/compiler/Compiler.scala
@@ -10,8 +10,6 @@ import qq.droste.data.Attr
 import qq.droste.data.Fix
 import cats.implicits._
 
-import scala.concurrent.ExecutionContext
-
 object Compiler {
 
   /** Given a schema, query, and mappings that specify resolvers for each field in the schema,
@@ -19,7 +17,7 @@ object Compiler {
     * @return an object of the query type
     */
   def compile[F[_]](schema: Schema, query: Query[Field.Fixed], mappings: QueryMappings[F])
-    (implicit ec: ExecutionContext, F: Monad[F]): F[JsObject] = {
+    (implicit F: Monad[F]): F[JsObject] = {
     val annotated: Query[Field.Annotated[FieldTypeInfo]] = annotateWithTypeInfo(schema, query)
 
     val mappingsFn = toMappingFunction(mappings)

--- a/fixql-core/src/main/scala/com/iterable/graphql/compiler/Compiler.scala
+++ b/fixql-core/src/main/scala/com/iterable/graphql/compiler/Compiler.scala
@@ -27,8 +27,7 @@ object Compiler {
     // The root resolvers are applied with a singleton list containing an empty Json object
     // as the set of parents
     val containersAtRoot = Seq(Json.obj())
-    val dbio = rootResolver.resolveBatch.apply(containersAtRoot).map(_.head.as[JsObject])
-    dbio
+    rootResolver.resolveBatch.apply(containersAtRoot).map(_.head.as[JsObject])
   }
 
   /** Given a schema and a query represented as a Field tree, returns a new Field tree annotated with the

--- a/fixql-core/src/main/scala/com/iterable/graphql/compiler/Compiler.scala
+++ b/fixql-core/src/main/scala/com/iterable/graphql/compiler/Compiler.scala
@@ -16,8 +16,7 @@ object Compiler {
     * generates the root resolver, then runs it.
     * @return an object of the query type
     */
-  def compile[F[_]](schema: Schema, query: Query[Field.Fixed], mappings: QueryMappings[F])
-    (implicit F: Monad[F]): F[JsObject] = {
+  def compile[F[_] : Monad](schema: Schema, query: Query[Field.Fixed], mappings: QueryMappings[F]): F[JsObject] = {
     val annotated: Query[Field.Annotated[FieldTypeInfo]] = annotateWithTypeInfo(schema, query)
 
     val mappingsFn = toMappingFunction(mappings)

--- a/fixql-core/src/main/scala/com/iterable/graphql/compiler/QueryReducer.scala
+++ b/fixql-core/src/main/scala/com/iterable/graphql/compiler/QueryReducer.scala
@@ -16,7 +16,7 @@ object QueryReducer {
     }
   }
 
-  def topLevelObjectsListWithSubfields[F[_]](dbio: => F[Seq[JsObject]])(implicit F: Monad[F]): QueryReducer[F, JsValue] = {
+  def topLevelObjectsListWithSubfields[F[_] : Monad](dbio: => F[Seq[JsObject]]): QueryReducer[F, JsValue] = {
     jsObjects { _ =>
       dbio
     } // This is an "illegal" state since top-level must be a Seq with one element

--- a/fixql-core/src/main/scala/com/iterable/graphql/compiler/QueryReducer.scala
+++ b/fixql-core/src/main/scala/com/iterable/graphql/compiler/QueryReducer.scala
@@ -43,7 +43,7 @@ object QueryReducer {
   * returned Resolver can depend on the (recursively generated) Resolvers for the subfields
   * of this field.
   */
-case class QueryReducer[F[_], +A](reducer: Field[Resolver[F, JsValue]] => Resolver[F, A]) {
+case class QueryReducer[F[_], A](reducer: Field[Resolver[F, JsValue]] => Resolver[F, A]) {
   def map[B](f: Seq[A] => Seq[B])(implicit ec: ExecutionContext, F: Monad[F]): QueryReducer[F, B] = QueryReducer[F, B] { field =>
     val resolved = reducer(field)
     ResolverFn(resolved.jsonFieldName) { parents =>

--- a/fixql-core/src/main/scala/com/iterable/graphql/compiler/QueryReducer.scala
+++ b/fixql-core/src/main/scala/com/iterable/graphql/compiler/QueryReducer.scala
@@ -89,7 +89,7 @@ case class QueryReducer[F[_], A](reducer: Field[Resolver[F, JsValue]] => Resolve
         entityJsons = resolved.map(x => x: JsObject) // apply the implicit coercion from A <:< JsObject
         entityJsonsWithSubfieldsValues <- mergeResolveSubfields(entityJsons, field)
       } yield {
-        entityJsonsWithSubfieldsValues: Seq[JsObject]
+        entityJsonsWithSubfieldsValues
       }
     }
   }

--- a/fixql-core/src/main/scala/com/iterable/graphql/compiler/QueryReducer.scala
+++ b/fixql-core/src/main/scala/com/iterable/graphql/compiler/QueryReducer.scala
@@ -8,7 +8,6 @@ import play.api.libs.json.JsObject
 import play.api.libs.json.JsValue
 import play.api.libs.json.Json
 import play.api.libs.json.Writes
-import slick.dbio.DBIO
 
 import scala.concurrent.ExecutionContext
 
@@ -108,8 +107,8 @@ case class QueryReducer[F[_], +A](reducer: Field[Resolver[F, JsValue]] => Resolv
     (implicit ec: ExecutionContext, F: Monad[F]): F[Seq[JsObject]] = {
     for {
       // for each subfield, the value for all rows
-      subfieldsValues: Seq[Seq[(String, JsValue)]] <- DBIO.sequence(
-        field.subfields.map { subfield =>
+      subfieldsValues: Seq[Seq[(String, JsValue)]] <- Traverse[List].sequence(
+        field.subfields.toList.map { subfield =>
           subfield.resolveBatch.apply(entityJsons).map(_.map(subfield.jsonFieldName -> _))
         }
       )

--- a/fixql-core/src/main/scala/com/iterable/graphql/compiler/QueryReducer.scala
+++ b/fixql-core/src/main/scala/com/iterable/graphql/compiler/QueryReducer.scala
@@ -42,8 +42,8 @@ object QueryReducer {
   * of this field.
   */
 case class QueryReducer[F[_], A](reducer: Field[Resolver[F, JsValue]] => Resolver[F, A]) {
-  def asJsValue(implicit subJsValue: A <:< JsValue, F: Functor[F]): QueryReducer[F, JsValue] = {
-    map(x => x: JsValue)
+  def as[B](implicit subJsValue: A <:< B, F: Functor[F]): QueryReducer[F, B] = {
+    map(x => x: B)
   }
 
   def map[B](f: A => B)(implicit F: Functor[F]): QueryReducer[F, B] = QueryReducer[F, B] { field =>
@@ -75,7 +75,7 @@ case class QueryReducer[F[_], A](reducer: Field[Resolver[F, JsValue]] => Resolve
     mapBatch { objs =>
       Seq(JsArray(objs.map(writes.writes)))
     }
-      .asJsValue
+      .as[JsValue]
   }
 
   /**

--- a/fixql-core/src/main/scala/com/iterable/graphql/compiler/ReducerHelpers.scala
+++ b/fixql-core/src/main/scala/com/iterable/graphql/compiler/ReducerHelpers.scala
@@ -10,13 +10,13 @@ import play.api.libs.json.JsValue
 import play.api.libs.json.Json
 
 trait ReducerHelpers {
-  protected final def standardMappings[F[_]](implicit F: Monad[F]): QueryMappings[F] = {
+  protected final def standardMappings[F[_] : Monad]: QueryMappings[F] = {
     rootMapping[F] orElse introspectionMappings[F]
   }
 
   /** Resolves the overall query by sequencing all the top-level resolvers.
     */
-  protected final def rootMapping[F[_]](implicit F: Monad[F]): QueryMappings[F] = {
+  protected final def rootMapping[F[_] : Monad]: QueryMappings[F] = {
     case (FieldTypeInfo(None, ""), Field("", _, _)) => QueryReducer { field: Field[Resolver[F, JsValue]] =>
       ResolverFn("") { containers =>
         for {
@@ -34,7 +34,7 @@ trait ReducerHelpers {
 
   /** Resolves queries for "__typename"
     */
-  protected final def introspectionMappings[F[_]](implicit F: Monad[F]): QueryMappings[F] = {
+  protected final def introspectionMappings[F[_] : Monad]: QueryMappings[F] = {
     val TypeNameField = Introspection.TypeNameMetaFieldDef.getName
 
     {

--- a/fixql-core/src/main/scala/com/iterable/graphql/compiler/ReducerHelpers.scala
+++ b/fixql-core/src/main/scala/com/iterable/graphql/compiler/ReducerHelpers.scala
@@ -1,6 +1,6 @@
 package com.iterable.graphql.compiler
 
-import cats.{Monad, Traverse}
+import cats.{Applicative, Traverse}
 import cats.implicits._
 import com.iterable.graphql.Field
 import com.iterable.graphql.compiler.FieldTypeInfo.ObjectField
@@ -10,13 +10,13 @@ import play.api.libs.json.JsValue
 import play.api.libs.json.Json
 
 trait ReducerHelpers {
-  protected final def standardMappings[F[_] : Monad]: QueryMappings[F] = {
+  protected final def standardMappings[F[_] : Applicative]: QueryMappings[F] = {
     rootMapping[F] orElse introspectionMappings[F]
   }
 
   /** Resolves the overall query by sequencing all the top-level resolvers.
     */
-  protected final def rootMapping[F[_] : Monad]: QueryMappings[F] = {
+  protected final def rootMapping[F[_] : Applicative]: QueryMappings[F] = {
     case (FieldTypeInfo(None, ""), Field("", _, _)) => QueryReducer { field: Field[Resolver[F, JsValue]] =>
       ResolverFn("") { containers =>
         for {
@@ -34,7 +34,7 @@ trait ReducerHelpers {
 
   /** Resolves queries for "__typename"
     */
-  protected final def introspectionMappings[F[_] : Monad]: QueryMappings[F] = {
+  protected final def introspectionMappings[F[_] : Applicative]: QueryMappings[F] = {
     val TypeNameField = Introspection.TypeNameMetaFieldDef.getName
 
     {

--- a/fixql-core/src/main/scala/com/iterable/graphql/compiler/ReducerHelpers.scala
+++ b/fixql-core/src/main/scala/com/iterable/graphql/compiler/ReducerHelpers.scala
@@ -9,16 +9,14 @@ import play.api.libs.json.JsString
 import play.api.libs.json.JsValue
 import play.api.libs.json.Json
 
-import scala.concurrent.ExecutionContext
-
 trait ReducerHelpers {
-  protected final def standardMappings[F[_]](implicit ec: ExecutionContext, F: Monad[F]): QueryMappings[F] = {
+  protected final def standardMappings[F[_]](implicit F: Monad[F]): QueryMappings[F] = {
     rootMapping[F] orElse introspectionMappings[F]
   }
 
   /** Resolves the overall query by sequencing all the top-level resolvers.
     */
-  protected final def rootMapping[F[_]](implicit ec: ExecutionContext, F: Monad[F]): QueryMappings[F] = {
+  protected final def rootMapping[F[_]](implicit F: Monad[F]): QueryMappings[F] = {
     case (FieldTypeInfo(None, ""), Field("", _, _)) => QueryReducer { field: Field[Resolver[F, JsValue]] =>
       ResolverFn("") { containers =>
         for {
@@ -36,7 +34,7 @@ trait ReducerHelpers {
 
   /** Resolves queries for "__typename"
     */
-  protected final def introspectionMappings[F[_]](implicit ec: ExecutionContext, F: Monad[F]): QueryMappings[F] = {
+  protected final def introspectionMappings[F[_]](implicit F: Monad[F]): QueryMappings[F] = {
     val TypeNameField = Introspection.TypeNameMetaFieldDef.getName
 
     {

--- a/fixql-core/src/main/scala/com/iterable/graphql/compiler/ReducerHelpers.scala
+++ b/fixql-core/src/main/scala/com/iterable/graphql/compiler/ReducerHelpers.scala
@@ -17,8 +17,8 @@ trait ReducerHelpers {
 
   /** Resolves the overall query by sequencing all the top-level resolvers.
     */
-  protected final def rootMapping(implicit ec: ExecutionContext): QueryMappings = {
-    case (FieldTypeInfo(None, ""), Field("", _, _)) => QueryReducer { field: Field[Resolver[JsValue]] =>
+  protected final def rootMapping[F[_]](implicit ec: ExecutionContext): QueryMappings = {
+    case (FieldTypeInfo(None, ""), Field("", _, _)) => QueryReducer { field: Field[Resolver[F, JsValue]] =>
       ResolverFn("") { containers =>
         for {
           subfieldsValues <- DBIO.sequence(field.subfields.map { subfieldResolver =>

--- a/fixql-core/src/main/scala/com/iterable/graphql/compiler/Resolver.scala
+++ b/fixql-core/src/main/scala/com/iterable/graphql/compiler/Resolver.scala
@@ -10,7 +10,7 @@ trait Resolver[F[_], A] {
   /** As the GraphQL tutorial says, "You can think of each field in a GraphQL query as a function or method of the
     * previous type which returns the next type." (https://graphql.org/learn/execution/)
     *
-    * A non-batched `resolve` method would have signature JsObject => DBIO[JsValue].
+    * A non-batched `resolve` method would have signature JsObject => F[JsValue].
     * Since batching is more general and more performant, we use a batched
     * signature below.
     *

--- a/fixql-core/src/main/scala/com/iterable/graphql/compiler/Resolver.scala
+++ b/fixql-core/src/main/scala/com/iterable/graphql/compiler/Resolver.scala
@@ -4,7 +4,7 @@ import play.api.libs.json.JsObject
 import slick.dbio.DBIO
 
 /** A trait with case class subclasses lets us optimize later */
-trait Resolver[+A] {
+trait Resolver[F[_], A] {
   def jsonFieldName: String
 
   /** As the GraphQL tutorial says, "You can think of each field in a GraphQL query as a function or method of the
@@ -17,7 +17,7 @@ trait Resolver[+A] {
     * @return function from containing object data to the data for this field returned as a sequence
     *         parallel with the input sequence
     */
-  def resolveBatch: Seq[JsObject] => DBIO[Seq[A]]
+  def resolveBatch: Seq[JsObject] => F[Seq[A]]
 }
 
-case class ResolverFn[A](jsonFieldName: String)(val resolveBatch: Seq[JsObject] => DBIO[Seq[A]]) extends Resolver[A]
+case class ResolverFn[F[_], A](jsonFieldName: String)(val resolveBatch: Seq[JsObject] => F[Seq[A]]) extends Resolver[F, A]

--- a/fixql-core/src/main/scala/com/iterable/graphql/compiler/Resolver.scala
+++ b/fixql-core/src/main/scala/com/iterable/graphql/compiler/Resolver.scala
@@ -1,7 +1,6 @@
 package com.iterable.graphql.compiler
 
 import play.api.libs.json.JsObject
-import slick.dbio.DBIO
 
 /** A trait with case class subclasses lets us optimize later */
 trait Resolver[F[_], A] {

--- a/fixql-core/src/main/scala/com/iterable/graphql/compiler/package.scala
+++ b/fixql-core/src/main/scala/com/iterable/graphql/compiler/package.scala
@@ -4,5 +4,5 @@ import play.api.libs.json.JsValue
 
 package object compiler {
   /** Maps a query field to a QueryReducer */
-  type QueryMappings = PartialFunction[(FieldTypeInfo, Field[Field.Annotated[FieldTypeInfo]]), QueryReducer[JsValue]]
+  type QueryMappings[F[_]] = PartialFunction[(FieldTypeInfo, Field[Field.Annotated[FieldTypeInfo]]), QueryReducer[F, JsValue]]
 }

--- a/fixql-core/src/test/scala/com/iterable/graphql/BuilderDslSpec.scala
+++ b/fixql-core/src/test/scala/com/iterable/graphql/BuilderDslSpec.scala
@@ -1,24 +1,25 @@
 package com.iterable.graphql
 
+import cats.Id
 import com.iterable.graphql.compiler.{Compiler, QueryMappings, QueryReducer, ReducerHelpers}
 import graphql.Scalars._
 import graphql.schema.GraphQLList.list
 import graphql.schema.GraphQLNonNull.nonNull
 import graphql.schema.idl.SchemaPrinter
-import graphql.schema.{GraphQLSchema, GraphQLType}
+import graphql.schema.{GraphQLObjectType, GraphQLSchema, GraphQLType}
 import org.scalatest.{FlatSpec, Matchers}
-import play.api.libs.json.{JsArray, JsObject, Json}
+import play.api.libs.json.{JsArray, JsObject, JsValue, Json}
 import slick.dbio.DBIO
 import slick.jdbc.JdbcBackend
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
-class BuilderDslSpec extends FlatSpec with SchemaAndMappingsMutableBuilderDsl with SchemaDsl with ReducerHelpers with Matchers {
+class BuilderDslSpec extends FlatSpec with SchemaAndMappingsMutableBuilderDsl[Id] with SchemaDsl with ReducerHelpers with Matchers {
 
   private val repo = new CharacterRepo
   private val slickDb = JdbcBackend.Database.forURL("jdbc:h2:mem:test", driver = "org.h2.Driver")
 
-  def buildSchemaAndMappings: (GraphQLSchema, QueryMappings) = {
+  def buildSchemaAndMappings: (GraphQLSchema, QueryMappings[Id]) = {
     schemaAndMappings { implicit builders =>
       // We have a circular reference between Droid and Human so we need to use type references
       val droidTypeRef = typeRef("Droid")
@@ -30,13 +31,11 @@ class BuilderDslSpec extends FlatSpec with SchemaAndMappingsMutableBuilderDsl wi
     }
   }
 
-  def humanMappings(droidType: GraphQLType) = WithBuilders { implicit builder =>
+  def humanMappings(droidType: GraphQLType) = WithBuilders[Id, GraphQLObjectType] { implicit builder =>
     withQueryType { implicit obj =>
-      field("humans", list(humanType)) ~> QueryReducer.jsObjects { _ =>
-        DBIO.successful(repo.getHumans(1000, 0).map(Json.toJson(_).as[JsObject]))
+      field("humans", list(humanType)) ~> QueryReducer.topLevelObjectsListWithSubfields[Id] {
+        repo.getHumans(1000, 0).map(Json.toJson(_).as[JsObject])
       }
-          .mergeResolveSubfields
-          .toTopLevelArray
     }
 
     // the lazy val is for the forward reference immediately above
@@ -51,13 +50,11 @@ class BuilderDslSpec extends FlatSpec with SchemaAndMappingsMutableBuilderDsl wi
     humanType
   }
 
-  def droidMappings(humanType: GraphQLType) = WithBuilders { implicit builder =>
+  def droidMappings(humanType: GraphQLType) = WithBuilders[Id, GraphQLObjectType] { implicit builder =>
     withQueryType { implicit obj =>
-      field("droids", list(droidType)) ~> QueryReducer.jsObjects { _ =>
-        DBIO.successful(repo.getDroids(1000, 0).map(Json.toJson(_).as[JsObject]))
+      field("droids", list(droidType)) ~> QueryReducer.topLevelObjectsListWithSubfields[Id] {
+        repo.getDroids(1000, 0).map(Json.toJson(_).as[JsObject])
       }
-          .mergeResolveSubfields
-          .toTopLevelArray
     }
 
     lazy val droidType = objectType("Droid") { implicit obj =>
@@ -97,18 +94,16 @@ class BuilderDslSpec extends FlatSpec with SchemaAndMappingsMutableBuilderDsl wi
         )
       )
 
-    val dbio = Compiler.compile(FromGraphQLJava.toSchemaFunction(schema), query, mappings)
-    slickDb.run(dbio).map { queryResults =>
-      val arr = (queryResults \ "humans").as[JsArray]
-      arr.value.size shouldEqual repo.getHumans(1000, 0).size
-      arr.value.head shouldEqual Json.obj(
-        "id" -> "1000",
-        "name" -> "Luke Skywalker",
-        "friends" -> Seq("1002", "1003", "2000", "2001"),
-        "appearsIn" -> Seq("NEWHOPE", "EMPIRE", "JEDI"),
-        "homePlanet" -> "Tatooine"
-      )
-    }
+    val queryResults = Compiler.compile(FromGraphQLJava.toSchemaFunction(schema), query, mappings)
+    val arr = (queryResults \ "humans").as[JsArray]
+    arr.value.size shouldEqual repo.getHumans(1000, 0).size
+    arr.value.head shouldEqual Json.obj(
+      "id" -> "1000",
+      "name" -> "Luke Skywalker",
+      "friends" -> Seq("1002", "1003", "2000", "2001"),
+      "appearsIn" -> Seq("NEWHOPE", "EMPIRE", "JEDI"),
+      "homePlanet" -> "Tatooine"
+    )
   }
 
   private val simplifiedStarWarsSchema =

--- a/fixql-core/src/test/scala/com/iterable/graphql/BuilderDslSpec.scala
+++ b/fixql-core/src/test/scala/com/iterable/graphql/BuilderDslSpec.scala
@@ -9,7 +9,6 @@ import graphql.schema.idl.SchemaPrinter
 import graphql.schema.{GraphQLObjectType, GraphQLSchema, GraphQLType}
 import org.scalatest.{FlatSpec, Matchers}
 import play.api.libs.json.{JsArray, JsObject, JsValue, Json}
-import slick.dbio.DBIO
 import slick.jdbc.JdbcBackend
 
 import scala.concurrent.ExecutionContext.Implicits.global

--- a/fixql-core/src/test/scala/com/iterable/graphql/BuilderDslSpec.scala
+++ b/fixql-core/src/test/scala/com/iterable/graphql/BuilderDslSpec.scala
@@ -3,20 +3,16 @@ package com.iterable.graphql
 import cats.Id
 import com.iterable.graphql.compiler.{Compiler, QueryMappings, QueryReducer, ReducerHelpers}
 import graphql.Scalars._
-import graphql.schema.GraphQLList.list
-import graphql.schema.GraphQLNonNull.nonNull
 import graphql.schema.idl.SchemaPrinter
 import graphql.schema.{GraphQLObjectType, GraphQLSchema, GraphQLType}
 import org.scalatest.{FlatSpec, Matchers}
-import play.api.libs.json.{JsArray, JsObject, JsValue, Json}
-import slick.jdbc.JdbcBackend
+import play.api.libs.json.{JsArray, JsObject, Json}
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
 class BuilderDslSpec extends FlatSpec with SchemaAndMappingsMutableBuilderDsl[Id] with SchemaDsl with ReducerHelpers with Matchers {
 
   private val repo = new CharacterRepo
-  private val slickDb = JdbcBackend.Database.forURL("jdbc:h2:mem:test", driver = "org.h2.Driver")
 
   def buildSchemaAndMappings: (GraphQLSchema, QueryMappings[Id]) = {
     schemaAndMappings { implicit builders =>

--- a/fixql-core/src/test/scala/com/iterable/graphql/BuilderDslSpec.scala
+++ b/fixql-core/src/test/scala/com/iterable/graphql/BuilderDslSpec.scala
@@ -88,7 +88,9 @@ class BuilderDslSpec extends FlatSpec with SchemaAndMappingsMutableBuilderDsl[Id
         Seq(
           Field("humans",
             subfields = Seq(
-              Field("name").fix
+              Field("id"),
+              Field("name"),
+              // TODO: add homePlanet
             )
           ).fix
         )
@@ -100,9 +102,6 @@ class BuilderDslSpec extends FlatSpec with SchemaAndMappingsMutableBuilderDsl[Id
     arr.value.head shouldEqual Json.obj(
       "id" -> "1000",
       "name" -> "Luke Skywalker",
-      "friends" -> Seq("1002", "1003", "2000", "2001"),
-      "appearsIn" -> Seq("NEWHOPE", "EMPIRE", "JEDI"),
-      "homePlanet" -> "Tatooine"
     )
   }
 

--- a/fixql-core/src/test/scala/com/iterable/graphql/BuilderDslSpec.scala
+++ b/fixql-core/src/test/scala/com/iterable/graphql/BuilderDslSpec.scala
@@ -8,7 +8,7 @@ import graphql.schema.{GraphQLObjectType, GraphQLSchema, GraphQLType}
 import org.scalatest.{FlatSpec, Matchers}
 import play.api.libs.json.{JsArray, JsObject, Json}
 
-class BuilderDslSpec extends FlatSpec with SchemaAndMappingsMutableBuilderDsl[Id] with SchemaDsl with ReducerHelpers with Matchers {
+class BuilderDslSpec extends FlatSpec with SchemaAndMappingsMutableBuilderDsl with SchemaDsl with ReducerHelpers with Matchers {
 
   private val repo = new CharacterRepo
 

--- a/fixql-core/src/test/scala/com/iterable/graphql/BuilderDslSpec.scala
+++ b/fixql-core/src/test/scala/com/iterable/graphql/BuilderDslSpec.scala
@@ -8,8 +8,6 @@ import graphql.schema.{GraphQLObjectType, GraphQLSchema, GraphQLType}
 import org.scalatest.{FlatSpec, Matchers}
 import play.api.libs.json.{JsArray, JsObject, Json}
 
-import scala.concurrent.ExecutionContext.Implicits.global
-
 class BuilderDslSpec extends FlatSpec with SchemaAndMappingsMutableBuilderDsl[Id] with SchemaDsl with ReducerHelpers with Matchers {
 
   private val repo = new CharacterRepo

--- a/fixql-core/src/test/scala/com/iterable/graphql/compiler/CompilerSpec.scala
+++ b/fixql-core/src/test/scala/com/iterable/graphql/compiler/CompilerSpec.scala
@@ -25,6 +25,7 @@ class CompilerSpec extends FlatSpec with Matchers with StarWarsSchema with Reduc
       case TopLevelField("droids") => QueryReducer.topLevelObjectsListWithSubfields[Id] {
         repo.getDroids(1000, 0).map(Json.toJson(_).as[JsObject])
       }
+      case ObjectField("Human", "id") => QueryReducer.mapped(_("id"))
       case ObjectField("Human", "name") => QueryReducer.mapped(_("name"))
     }: QueryMappings[Id]).orElse(rootMapping)
 
@@ -34,7 +35,8 @@ class CompilerSpec extends FlatSpec with Matchers with StarWarsSchema with Reduc
         Seq(
           Field("humans",
             subfields = Seq(
-              Field("name").fix
+              Field("id"),
+              Field("name"),
             )
           ).fix
         )
@@ -44,11 +46,8 @@ class CompilerSpec extends FlatSpec with Matchers with StarWarsSchema with Reduc
     val arr = (queryResults \ "humans").as[JsArray]
     arr.value.size shouldEqual repo.getHumans(1000, 0).size
     arr.value.head shouldEqual Json.obj(
-        "id" -> "1000",
-        "name" -> "Luke Skywalker",
-        "friends" -> Seq("1002", "1003", "2000", "2001"),
-        "appearsIn" -> Seq("NEWHOPE", "EMPIRE", "JEDI"),
-        "homePlanet" -> "Tatooine"
-      )
+      "id" -> "1000",
+      "name" -> "Luke Skywalker",
+    )
   }
 }

--- a/fixql-core/src/test/scala/com/iterable/graphql/compiler/CompilerSpec.scala
+++ b/fixql-core/src/test/scala/com/iterable/graphql/compiler/CompilerSpec.scala
@@ -1,14 +1,15 @@
 package com.iterable.graphql.compiler
 
+import cats.Id
 import com.iterable.graphql.FromGraphQLJava.parseSchema
 import com.iterable.graphql.compiler.FieldTypeInfo.{ObjectField, TopLevelField}
 import com.iterable.graphql.{CharacterRepo, Field, FromGraphQLJava, Query, StarWarsSchema}
-import org.scalatest.{AsyncFlatSpec, Matchers}
+import org.scalatest.{FlatSpec, Matchers}
 import play.api.libs.json.{JsArray, JsObject, Json}
 import slick.jdbc.JdbcBackend
-import slick.dbio.DBIO
+import scala.concurrent.ExecutionContext.Implicits.global
 
-class CompilerSpec extends AsyncFlatSpec with Matchers with StarWarsSchema with ReducerHelpers {
+class CompilerSpec extends FlatSpec with Matchers with StarWarsSchema with ReducerHelpers {
 
   private val slickDb = JdbcBackend.Database.forURL("jdbc:h2:mem:test", driver = "org.h2.Driver")
 
@@ -18,15 +19,14 @@ class CompilerSpec extends AsyncFlatSpec with Matchers with StarWarsSchema with 
     val repo = new CharacterRepo
 
     val resolvers = ({
-      case TopLevelField("humans") => QueryReducer.jsObjects { _ =>
-        DBIO.successful(repo.getHumans(1000, 0).map(Json.toJson(_).as[JsObject]))
+      case TopLevelField("humans") => QueryReducer.topLevelObjectsListWithSubfields[Id] {
+        repo.getHumans(1000, 0).map(Json.toJson(_).as[JsObject])
       }
-          .toTopLevelArray
-      case TopLevelField("droids") => QueryReducer.jsObjects { _ =>
-        DBIO.successful(repo.getDroids(1000, 0).map(Json.toJson(_).as[JsObject]))
+      case TopLevelField("droids") => QueryReducer.topLevelObjectsListWithSubfields[Id] {
+        repo.getDroids(1000, 0).map(Json.toJson(_).as[JsObject])
       }
       case ObjectField("Human", "name") => QueryReducer.mapped(_("name"))
-    }: QueryMappings).orElse(rootMapping)
+    }: QueryMappings[Id]).orElse(rootMapping)
 
     import qq.droste.syntax.fix._
     val query: Query[Field.Fixed] =
@@ -40,17 +40,15 @@ class CompilerSpec extends AsyncFlatSpec with Matchers with StarWarsSchema with 
         )
       )
 
-    val dbio = Compiler.compile(schema, query, resolvers)
-    slickDb.run(dbio).map { queryResults =>
-      val arr = (queryResults \ "humans").as[JsArray]
-      arr.value.size shouldEqual repo.getHumans(1000, 0).size
-      arr.value.head shouldEqual Json.obj(
-          "id" -> "1000",
-          "name" -> "Luke Skywalker",
-          "friends" -> Seq("1002", "1003", "2000", "2001"),
-          "appearsIn" -> Seq("NEWHOPE", "EMPIRE", "JEDI"),
-          "homePlanet" -> "Tatooine"
-        )
-    }
+    val queryResults = Compiler.compile(schema, query, resolvers)
+    val arr = (queryResults \ "humans").as[JsArray]
+    arr.value.size shouldEqual repo.getHumans(1000, 0).size
+    arr.value.head shouldEqual Json.obj(
+        "id" -> "1000",
+        "name" -> "Luke Skywalker",
+        "friends" -> Seq("1002", "1003", "2000", "2001"),
+        "appearsIn" -> Seq("NEWHOPE", "EMPIRE", "JEDI"),
+        "homePlanet" -> "Tatooine"
+      )
   }
 }

--- a/fixql-core/src/test/scala/com/iterable/graphql/compiler/CompilerSpec.scala
+++ b/fixql-core/src/test/scala/com/iterable/graphql/compiler/CompilerSpec.scala
@@ -6,12 +6,9 @@ import com.iterable.graphql.compiler.FieldTypeInfo.{ObjectField, TopLevelField}
 import com.iterable.graphql.{CharacterRepo, Field, FromGraphQLJava, Query, StarWarsSchema}
 import org.scalatest.{FlatSpec, Matchers}
 import play.api.libs.json.{JsArray, JsObject, Json}
-import slick.jdbc.JdbcBackend
 import scala.concurrent.ExecutionContext.Implicits.global
 
 class CompilerSpec extends FlatSpec with Matchers with StarWarsSchema with ReducerHelpers {
-
-  private val slickDb = JdbcBackend.Database.forURL("jdbc:h2:mem:test", driver = "org.h2.Driver")
 
   "Compiler" should "compile" in {
     val graphQLSchema = parseSchema(starWarsSchema)

--- a/fixql-core/src/test/scala/com/iterable/graphql/compiler/CompilerSpec.scala
+++ b/fixql-core/src/test/scala/com/iterable/graphql/compiler/CompilerSpec.scala
@@ -6,7 +6,6 @@ import com.iterable.graphql.compiler.FieldTypeInfo.{ObjectField, TopLevelField}
 import com.iterable.graphql.{CharacterRepo, Field, FromGraphQLJava, Query, StarWarsSchema}
 import org.scalatest.{FlatSpec, Matchers}
 import play.api.libs.json.{JsArray, JsObject, Json}
-import scala.concurrent.ExecutionContext.Implicits.global
 
 class CompilerSpec extends FlatSpec with Matchers with StarWarsSchema with ReducerHelpers {
 

--- a/fixql-derivation/src/main/scala/com/iterable/graphql/derivation/DerivationBuilderDsl.scala
+++ b/fixql-derivation/src/main/scala/com/iterable/graphql/derivation/DerivationBuilderDsl.scala
@@ -1,6 +1,6 @@
 package com.iterable.graphql.derivation
 
-import cats.Monad
+import cats.Applicative
 import com.iterable.graphql.{MutableMappingsBuilder, SchemaAndMappingsMutableBuilderDsl}
 import graphql.schema.{GraphQLObjectType, GraphQLOutputType}
 import shapeless.ops.hlist
@@ -20,7 +20,7 @@ trait DerivationBuilderDsl extends SchemaAndMappingsMutableBuilderDsl {
   }
 
   class AddDerived[T](name: String)(implicit obj: GraphQLObjectType.Builder) extends SingletonProductArgs {
-    def fieldsAndMappingsProduct[F[_] : Monad, L <: HList, MV <: HList, S <: HList, V <: HList, L2 <: HList, K <: HList]
+    def fieldsAndMappingsProduct[F[_] : Applicative, L <: HList, MV <: HList, S <: HList, V <: HList, L2 <: HList, K <: HList]
     (selections: S)
     (implicit gen: LabelledGeneric.Aux[T, L],
      select: SelectAll.Aux[L, S, V],
@@ -49,7 +49,7 @@ trait DerivationBuilderDsl extends SchemaAndMappingsMutableBuilderDsl {
       obj.fields(derived.getFieldDefinitions)
     }
 
-    def mappingsProduct[F[_] : Monad, L <: HList, K <: HList, S <: HList]
+    def mappingsProduct[F[_] : Applicative, L <: HList, K <: HList, S <: HList]
     (selections: S)
     (implicit mappings: MutableMappingsBuilder[F],
      gen: LabelledGeneric.Aux[T, L],

--- a/fixql-derivation/src/main/scala/com/iterable/graphql/derivation/DerivationBuilderDsl.scala
+++ b/fixql-derivation/src/main/scala/com/iterable/graphql/derivation/DerivationBuilderDsl.scala
@@ -1,5 +1,6 @@
 package com.iterable.graphql.derivation
 
+import cats.Monad
 import com.iterable.graphql.{MutableMappingsBuilder, SchemaAndMappingsMutableBuilderDsl}
 import graphql.schema.{GraphQLObjectType, GraphQLOutputType}
 import shapeless.ops.hlist
@@ -19,7 +20,7 @@ trait DerivationBuilderDsl extends SchemaAndMappingsMutableBuilderDsl {
   }
 
   class AddDerived[T](name: String)(implicit obj: GraphQLObjectType.Builder) extends SingletonProductArgs {
-    def fieldsAndMappingsProduct[L <: HList, MV <: HList, S <: HList, V <: HList, L2 <: HList, K <: HList]
+    def fieldsAndMappingsProduct[F[_] : Monad, L <: HList, MV <: HList, S <: HList, V <: HList, L2 <: HList, K <: HList]
     (selections: S)
     (implicit gen: LabelledGeneric.Aux[T, L],
      select: SelectAll.Aux[L, S, V],
@@ -27,7 +28,7 @@ trait DerivationBuilderDsl extends SchemaAndMappingsMutableBuilderDsl {
      mapValues: MapValuesNull.Aux[ToGraphQLType.type, L2, MV],
      toMap: ToMap.Aux[MV, _, GraphQLOutputType],
     // Simply concatenate the necessary implicits for both functions, somewhat redundantly
-     mappings: MutableMappingsBuilder,
+     mappings: MutableMappingsBuilder[F],
      keys: Keys.Aux[L, K],
      selectKeys: hlist.SelectAll[K, S],
      set: ToTraversable.Aux[S, Set, Symbol]
@@ -48,9 +49,9 @@ trait DerivationBuilderDsl extends SchemaAndMappingsMutableBuilderDsl {
       obj.fields(derived.getFieldDefinitions)
     }
 
-    def mappingsProduct[L <: HList, K <: HList, S <: HList]
+    def mappingsProduct[F[_] : Monad, L <: HList, K <: HList, S <: HList]
     (selections: S)
-    (implicit mappings: MutableMappingsBuilder,
+    (implicit mappings: MutableMappingsBuilder[F],
      gen: LabelledGeneric.Aux[T, L],
      keys: Keys.Aux[L, K],
      select: hlist.SelectAll[K, S],

--- a/fixql-derivation/src/main/scala/com/iterable/graphql/derivation/DeriveMappings.scala
+++ b/fixql-derivation/src/main/scala/com/iterable/graphql/derivation/DeriveMappings.scala
@@ -1,5 +1,6 @@
 package com.iterable.graphql.derivation
 
+import cats.Monad
 import com.iterable.graphql.compiler.FieldTypeInfo.ObjectField
 import com.iterable.graphql.compiler.{QueryMappings, QueryReducer}
 import play.api.libs.json.{JsNull, JsValue}
@@ -19,10 +20,10 @@ object DeriveMappings {
   def apply[T](typeName: String) = new Derive[T](typeName)
 
   class Derive[T](TypeName: String) extends SingletonProductArgs {
-    def allFields[L <: HList, K <: HList]
+    def allFields[F[_] : Monad, L <: HList, K <: HList]
     (implicit gen: LabelledGeneric.Aux[T, L],
      keys: Keys.Aux[L, K],
-     set: ToTraversable.Aux[K, Set, Symbol]): QueryMappings = {
+     set: ToTraversable.Aux[K, Set, Symbol]): QueryMappings[F] = {
       val fieldNames = set.apply(keys.apply()).map(_.name)
       fieldMappings(TypeName, fieldNames)
     }
@@ -31,18 +32,18 @@ object DeriveMappings {
       * customize anything about a field mapping, you should exclude the field
       * from automatic derivation and simply define the field's mapping explicitly.
       */
-    def fieldsProduct[L <: HList, K <: HList, S <: HList]
+    def fieldsProduct[F[_] : Monad, L <: HList, K <: HList, S <: HList]
     (selections: S)
     (implicit gen: LabelledGeneric.Aux[T, L],
      keys: Keys.Aux[L, K],
      select: SelectAll[K, S],
-     set: ToTraversable.Aux[S, Set, Symbol]): QueryMappings = {
+     set: ToTraversable.Aux[S, Set, Symbol]): QueryMappings[F] = {
       val fieldNames = set.apply(select.apply(keys.apply())).map(_.name)
       fieldMappings(TypeName, fieldNames)
     }
   }
 
-  private def fieldMappings(TypeName: String, fieldNames: Set[String]) = {
+  private def fieldMappings[F[_] : Monad](TypeName: String, fieldNames: Set[String]) = {
     ({ case ObjectField(TypeName, fieldName) if fieldNames.contains(fieldName) =>
       QueryReducer.mapped { parent =>
         // If the parent has defined this field as an Option, then Json serialization
@@ -54,6 +55,6 @@ object DeriveMappings {
         // GraphQL spec.
         (parent \ fieldName).asOpt[JsValue].getOrElse(JsNull)
       }
-    }: QueryMappings)
+    }: QueryMappings[F])
   }
 }

--- a/fixql-derivation/src/main/scala/com/iterable/graphql/derivation/DeriveMappings.scala
+++ b/fixql-derivation/src/main/scala/com/iterable/graphql/derivation/DeriveMappings.scala
@@ -1,6 +1,6 @@
 package com.iterable.graphql.derivation
 
-import cats.Monad
+import cats.Applicative
 import com.iterable.graphql.compiler.FieldTypeInfo.ObjectField
 import com.iterable.graphql.compiler.{QueryMappings, QueryReducer}
 import play.api.libs.json.{JsNull, JsValue}
@@ -20,7 +20,7 @@ object DeriveMappings {
   def apply[T](typeName: String) = new Derive[T](typeName)
 
   class Derive[T](TypeName: String) extends SingletonProductArgs {
-    def allFields[F[_] : Monad, L <: HList, K <: HList]
+    def allFields[F[_] : Applicative, L <: HList, K <: HList]
     (implicit gen: LabelledGeneric.Aux[T, L],
      keys: Keys.Aux[L, K],
      set: ToTraversable.Aux[K, Set, Symbol]): QueryMappings[F] = {
@@ -32,7 +32,7 @@ object DeriveMappings {
       * customize anything about a field mapping, you should exclude the field
       * from automatic derivation and simply define the field's mapping explicitly.
       */
-    def fieldsProduct[F[_] : Monad, L <: HList, K <: HList, S <: HList]
+    def fieldsProduct[F[_] : Applicative, L <: HList, K <: HList, S <: HList]
     (selections: S)
     (implicit gen: LabelledGeneric.Aux[T, L],
      keys: Keys.Aux[L, K],
@@ -43,7 +43,7 @@ object DeriveMappings {
     }
   }
 
-  private def fieldMappings[F[_] : Monad](TypeName: String, fieldNames: Set[String]) = {
+  private def fieldMappings[F[_] : Applicative](TypeName: String, fieldNames: Set[String]) = {
     ({ case ObjectField(TypeName, fieldName) if fieldNames.contains(fieldName) =>
       QueryReducer.mapped { parent =>
         // If the parent has defined this field as an Option, then Json serialization

--- a/fixql-derivation/src/test/scala/com/iterable/graphql/derivation/DerivationSpec.scala
+++ b/fixql-derivation/src/test/scala/com/iterable/graphql/derivation/DerivationSpec.scala
@@ -9,7 +9,6 @@ import graphql.schema.idl.SchemaPrinter
 import io.circe.Json
 import org.scalatest.{FlatSpec, Matchers}
 import play.api.libs.json.{JsArray, JsNull, JsObject, JsString, Json => PlayJson}
-import slick.jdbc.JdbcBackend
 
 class DerivationSpec extends FlatSpec with Matchers
   with SchemaAndMappingsMutableBuilderDsl with ReducerHelpers with DerivationBuilderDsl {
@@ -30,7 +29,6 @@ class DerivationSpec extends FlatSpec with Matchers
   }
 
   private val repo = new CharacterRepo
-  private val slickDb = JdbcBackend.Database.forURL("jdbc:h2:mem:test", driver = "org.h2.Driver")
 
   // TODO: add negative tests to verify query syntax validation fails when you
   // specify fields that aren't in the case class


### PR DESCRIPTION
Remove the dependency on Slick and all uses of `DBIO`. Replace `DBIO[T]` with `F[T]` where `F[_]` is a type parameter and where necessary we require `F[_] : Monad`. This is the "standard" approach taken by other libraries to abstract over effect types (DBIO, Future, IO, etc.)