### PR TITLE
Json

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -36,6 +36,7 @@ lazy val core = Project("fixql-core", file("fixql-core"))
     "io.circe" %% "circe-optics" % "0.9.3",
 
     "com.typesafe.play" %% "play-json" % "2.7.1",
+    "org.typelevel" %% "jawn-parser" % "0.14.2",
   ))
   .settings(addCompilerPlugin("com.olegpy" %% "better-monadic-for" % "0.3.0"))
 

--- a/build.sbt
+++ b/build.sbt
@@ -37,6 +37,7 @@ lazy val core = Project("fixql-core", file("fixql-core"))
 
     "com.typesafe.play" %% "play-json" % "2.7.1",
     "org.typelevel" %% "jawn-parser" % "0.14.2",
+    "org.typelevel" %% "jawn-play" % "0.14.2" % Test,
   ))
   .settings(addCompilerPlugin("com.olegpy" %% "better-monadic-for" % "0.3.0"))
 

--- a/fixql-core/src/main/scala/com/iterable/graphql/SchemaAndMappingsMutableBuilderDsl.scala
+++ b/fixql-core/src/main/scala/com/iterable/graphql/SchemaAndMappingsMutableBuilderDsl.scala
@@ -36,7 +36,7 @@ class MutableMappingsBuilder[F[_], T] {
   *
   * @tparam T useful to return a value (e.g. an object type) from this definition block
   */
-case class WithBuilders[F[_], T](mutate: Builders[F, T] => T) {
+case class WithBuilders[F[_], T, A](mutate: Builders[F, T] => A) {
 
   /** Includes our field and mapping definitions in the current context. Example:
     *

--- a/fixql-core/src/main/scala/com/iterable/graphql/SchemaAndMappingsMutableBuilderDsl.scala
+++ b/fixql-core/src/main/scala/com/iterable/graphql/SchemaAndMappingsMutableBuilderDsl.scala
@@ -104,7 +104,7 @@ trait SchemaAndMappingsMutableBuilderDsl extends SchemaDsl {
   }
 
   implicit class FieldExtensions(field: GraphQLFieldDefinition) {
-    def ~>[F[_], T](reducer: QueryReducer[F, T])
+    def ~>[F[_], T](reducer: QueryReducer[F, T, T])
           (implicit builders: Builders[F, T], obj: GraphQLObjectType.Builder, mappings: MutableMappingsBuilder[F, T]) = {
       obj.field(field)
       val ObjectName = obj.build.getName

--- a/fixql-core/src/main/scala/com/iterable/graphql/SchemaAndMappingsMutableBuilderDsl.scala
+++ b/fixql-core/src/main/scala/com/iterable/graphql/SchemaAndMappingsMutableBuilderDsl.scala
@@ -8,14 +8,14 @@ import play.api.libs.json.JsValue
 /**
   * Mutable builder for a QueryMappings partial function
   */
-class MutableMappingsBuilder[F[_]] {
-  private var mappings: QueryMappings[F] = { case _ if false => null }
+class MutableMappingsBuilder[F[_], T] {
+  private var mappings: QueryMappings[F, T] = { case _ if false => null }
 
-  def add(m: QueryMappings[F]): Unit = {
+  def add(m: QueryMappings[F, T]): Unit = {
     mappings = mappings orElse m
   }
 
-  def build: QueryMappings[F] = mappings
+  def build: QueryMappings[F, T] = mappings
 }
 
 /** Supports breaking up schema definition into multiple def's. For example, this lets you do:
@@ -36,7 +36,7 @@ class MutableMappingsBuilder[F[_]] {
   *
   * @tparam T useful to return a value (e.g. an object type) from this definition block
   */
-case class WithBuilders[F[_], T](mutate: Builders[F] => T) {
+case class WithBuilders[F[_], T](mutate: Builders[F, T] => T) {
 
   /** Includes our field and mapping definitions in the current context. Example:
     *
@@ -46,7 +46,7 @@ case class WithBuilders[F[_], T](mutate: Builders[F] => T) {
     *   }
     * }
     */
-  def include(implicit builder: Builders[F]) = {
+  def include(implicit builder: Builders[F, T]) = {
     mutate(builder)
   }
 }
@@ -55,9 +55,9 @@ case class WithBuilders[F[_], T](mutate: Builders[F] => T) {
   * Top-level builders - doesn't include object-type builders other than the builder for the
   * query type
   */
-case class Builders[F[_]](
+case class Builders[F[_], T](
   schemaBuilder: GraphQLSchema.Builder = GraphQLSchema.newSchema(),
-  mappingsBuilder: MutableMappingsBuilder[F] = new MutableMappingsBuilder[F],
+  mappingsBuilder: MutableMappingsBuilder[F, T] = new MutableMappingsBuilder[F, T],
   queryTypeBuilder: GraphQLObjectType.Builder,
 ) {
   lazy val queryTypeName = queryTypeBuilder.build.getName
@@ -69,23 +69,23 @@ case class Builders[F[_]](
   */
 trait SchemaAndMappingsMutableBuilderDsl extends SchemaDsl {
 
-  protected final def schemaAndMappings[F[_]](mutate: Builders[F] => Unit) = {
-    val builders = Builders[F](queryTypeBuilder = objectType("QueryType"))
+  protected final def schemaAndMappings[F[_], T](mutate: Builders[F, T] => Unit) = {
+    val builders = Builders[F, T](queryTypeBuilder = objectType("QueryType"))
     mutate(builders)
     builders.schemaBuilder.query(builders.queryTypeBuilder.build)
     (builders.schemaBuilder.build, builders.mappingsBuilder.build)
   }
 
-  implicit def mappingsFromBuilders[F[_]](implicit builder: Builders[F]): MutableMappingsBuilder[F] = builder.mappingsBuilder
+  implicit def mappingsFromBuilders[F[_], T](implicit builder: Builders[F, T]): MutableMappingsBuilder[F, T] = builder.mappingsBuilder
 
   /** The Query type uses an ordinary object builder. But since we can't have multiple implicit object builders in
     * lexical scope, uses of the query type builder must be delimited.
     */
-  protected final def withQueryType[F[_]](mutate: GraphQLObjectType.Builder => Unit)(implicit builder: Builders[F]) = {
+  protected final def withQueryType[F[_], T](mutate: GraphQLObjectType.Builder => Unit)(implicit builder: Builders[F, T]) = {
     mutate(builder.queryTypeBuilder)
   }
 
-  protected final def addMappings[F[_]](mappings: QueryMappings[F])(implicit mappingsBuilder: MutableMappingsBuilder[F]): Unit = {
+  protected final def addMappings[F[_], T](mappings: QueryMappings[F, T])(implicit mappingsBuilder: MutableMappingsBuilder[F, T]): Unit = {
     mappingsBuilder.add(mappings)
   }
 
@@ -104,8 +104,8 @@ trait SchemaAndMappingsMutableBuilderDsl extends SchemaDsl {
   }
 
   implicit class FieldExtensions(field: GraphQLFieldDefinition) {
-    def ~>[F[_]](reducer: QueryReducer[F, JsValue])
-          (implicit builders: Builders[F], obj: GraphQLObjectType.Builder, mappings: MutableMappingsBuilder[F]) = {
+    def ~>[F[_], T](reducer: QueryReducer[F, T])
+          (implicit builders: Builders[F, T], obj: GraphQLObjectType.Builder, mappings: MutableMappingsBuilder[F, T]) = {
       obj.field(field)
       val ObjectName = obj.build.getName
       val FieldName = field.getName

--- a/fixql-core/src/main/scala/com/iterable/graphql/compiler/QueryReducer.scala
+++ b/fixql-core/src/main/scala/com/iterable/graphql/compiler/QueryReducer.scala
@@ -98,7 +98,7 @@ case class QueryReducer[F[_], T, A](reducer: Field[Resolver[F, T]] => Resolver[F
     * type Seq[Seq[T]] and must be flattened before being passed into subfield resolvers,
     * then unflattened before being merged.
     */
-  def mergeResolveSubfieldsMany(implicit subseqs: A <:< Seq[JsObject], F: Monad[F], JSON: SimpleFacade[T]) = QueryReducer[F, T, JsArray] { field =>
+  def mergeResolveSubfieldsMany(implicit subseqs: A <:< Seq[JsObject], F: Monad[F], JSON: SimpleFacade[T]) = QueryReducer[F, T, T] { field =>
     val baseResolver = reducer(field)
     ResolverFn(baseResolver.jsonFieldName) { parents =>
       for {
@@ -107,7 +107,7 @@ case class QueryReducer[F[_], T, A](reducer: Field[Resolver[F, T]] => Resolver[F
         allEntitiesWithSubfieldsValues <- doMergeResolveSubfields(allEntities, field)
         mergedEntitiesByParent = reverseFlatten(entitiesByParent, allEntitiesWithSubfieldsValues)
       } yield {
-        mergedEntitiesByParent.map(JsArray(_))
+        mergedEntitiesByParent.map(xs => JSON.jarray(xs.toList))
       }
     }
   }

--- a/fixql-core/src/main/scala/com/iterable/graphql/compiler/QueryReducerHelpers.scala
+++ b/fixql-core/src/main/scala/com/iterable/graphql/compiler/QueryReducerHelpers.scala
@@ -1,0 +1,36 @@
+package com.iterable.graphql.compiler
+
+import cats.{Applicative, Monad}
+import com.iterable.graphql.Field
+import org.typelevel.jawn.SimpleFacade
+import play.api.libs.json.{JsObject, JsValue}
+
+trait QueryReducerHelpers[T] {
+  def mapped[F[_], A](f: JsObject => A)(implicit F: Applicative[F]): QueryReducer[F, T, A] = QueryReducer[F, T, A] { field: Field[Resolver[F, T]] =>
+    ResolverFn(field.name) { parents =>
+      F.pure(parents.map(f))
+    }
+  }
+
+  def topLevelObjectsListWithSubfields[F[_] : Monad]
+  (dbio: => F[Seq[JsObject]])
+  (implicit JSON: SimpleFacade[T]): QueryReducer[F, T, T] = {
+    jsObjects { _ =>
+      dbio
+    } // This is an "illegal" state since top-level must be a Seq with one element
+      .mergeResolveSubfields
+      .toTopLevelArray
+  }
+
+  def jsObjects[F[_]](f: Seq[JsObject] => F[Seq[JsObject]]): QueryReducer[F, T, JsObject] = QueryReducer[F, T, JsObject] { field: Field[Resolver[F, T]] =>
+    ResolverFn(field.name) { parents =>
+      f(parents)
+    }
+  }
+
+  def jsValues[F[_]](f: Seq[JsObject] => F[Seq[JsValue]]): QueryReducer[F, T, JsValue] = QueryReducer[F, T, JsValue] { field: Field[Resolver[F, T]] =>
+    ResolverFn(field.name) { parents =>
+      f(parents)
+    }
+  }
+}

--- a/fixql-core/src/main/scala/com/iterable/graphql/compiler/ReducerHelpers.scala
+++ b/fixql-core/src/main/scala/com/iterable/graphql/compiler/ReducerHelpers.scala
@@ -17,7 +17,7 @@ trait ReducerHelpers {
   /** Resolves the overall query by sequencing all the top-level resolvers.
     */
   protected final def rootMapping[F[_] : Applicative, T]: QueryMappings[F, T] = {
-    case (FieldTypeInfo(None, ""), Field("", _, _)) => QueryReducer { field: Field[Resolver[F, JsValue]] =>
+    case (FieldTypeInfo(None, ""), Field("", _, _)) => QueryReducer { field: Field[Resolver[F, T]] =>
       ResolverFn("") { containers =>
         for {
           subfieldsValues <- Traverse[List].sequence(field.subfields.toList.map { subfieldResolver =>

--- a/fixql-core/src/main/scala/com/iterable/graphql/compiler/ReducerHelpers.scala
+++ b/fixql-core/src/main/scala/com/iterable/graphql/compiler/ReducerHelpers.scala
@@ -10,13 +10,13 @@ import play.api.libs.json.JsValue
 import play.api.libs.json.Json
 
 trait ReducerHelpers {
-  protected final def standardMappings[F[_] : Applicative]: QueryMappings[F] = {
-    rootMapping[F] orElse introspectionMappings[F]
+  protected final def standardMappings[F[_] : Applicative, T]: QueryMappings[F, T] = {
+    rootMapping[F, T] orElse introspectionMappings[F, T]
   }
 
   /** Resolves the overall query by sequencing all the top-level resolvers.
     */
-  protected final def rootMapping[F[_] : Applicative]: QueryMappings[F] = {
+  protected final def rootMapping[F[_] : Applicative, T]: QueryMappings[F, T] = {
     case (FieldTypeInfo(None, ""), Field("", _, _)) => QueryReducer { field: Field[Resolver[F, JsValue]] =>
       ResolverFn("") { containers =>
         for {
@@ -34,7 +34,7 @@ trait ReducerHelpers {
 
   /** Resolves queries for "__typename"
     */
-  protected final def introspectionMappings[F[_] : Applicative]: QueryMappings[F] = {
+  protected final def introspectionMappings[F[_] : Applicative, T]: QueryMappings[F, T] = {
     val TypeNameField = Introspection.TypeNameMetaFieldDef.getName
 
     {

--- a/fixql-core/src/main/scala/com/iterable/graphql/compiler/package.scala
+++ b/fixql-core/src/main/scala/com/iterable/graphql/compiler/package.scala
@@ -4,5 +4,5 @@ import play.api.libs.json.JsValue
 
 package object compiler {
   /** Maps a query field to a QueryReducer */
-  type QueryMappings[F[_], T] = PartialFunction[(FieldTypeInfo, Field[Field.Annotated[FieldTypeInfo]]), QueryReducer[F, T]]
+  type QueryMappings[F[_], T] = PartialFunction[(FieldTypeInfo, Field[Field.Annotated[FieldTypeInfo]]), QueryReducer[F, T, T]]
 }

--- a/fixql-core/src/main/scala/com/iterable/graphql/compiler/package.scala
+++ b/fixql-core/src/main/scala/com/iterable/graphql/compiler/package.scala
@@ -4,5 +4,5 @@ import play.api.libs.json.JsValue
 
 package object compiler {
   /** Maps a query field to a QueryReducer */
-  type QueryMappings[F[_]] = PartialFunction[(FieldTypeInfo, Field[Field.Annotated[FieldTypeInfo]]), QueryReducer[F, JsValue]]
+  type QueryMappings[F[_], T] = PartialFunction[(FieldTypeInfo, Field[Field.Annotated[FieldTypeInfo]]), QueryReducer[F, T]]
 }


### PR DESCRIPTION
Attempt at removing the dependency on and uses of play-json and replacing it with an abstracted dependency via Jawn's type classes.

The generic type T is expected to be `JsValue` for play-json and `Json` for circe.

One thing I'm not sure if I'm happy with is losing static knowledge of `JsObject`s (or JsArrays for that matter). Seems like it might be OK?

To recover it I'd have to introduce my own type class `trait JsonLike` (possibly containing the Jawn type class) with a dependent type `type Obj` that points to the equivalent of JsObject with transformations between JsObject and T.